### PR TITLE
Update deprecated allow_tags to format_html

### DIFF
--- a/src/webmention/admin.py
+++ b/src/webmention/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.utils.html import format_html
 
 from .models import WebMentionResponse
 

--- a/src/webmention/admin.py
+++ b/src/webmention/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from .models import WebMentionResponse
 

--- a/src/webmention/models.py
+++ b/src/webmention/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.html import format_html
 
 
 class WebMentionResponse(models.Model):

--- a/src/webmention/models.py
+++ b/src/webmention/models.py
@@ -18,15 +18,13 @@ class WebMentionResponse(models.Model):
         return self.source
 
     def source_for_admin(self):
-        return '<a href="{href}">{href}</a>'.format(href=self.source)
+        return format_html('<a href="{href}">{href}</a>'.format(href=self.source))
 
-    source_for_admin.allow_tags = True
     source_for_admin.short_description = "source"
 
     def response_to_for_admin(self):
-        return '<a href="{href}">{href}</a>'.format(href=self.response_to)
+        return format_html('<a href="{href}">{href}</a>'.format(href=self.response_to))
 
-    response_to_for_admin.allow_tags = True
     response_to_for_admin.short_description = "response to"
 
     def invalidate(self):


### PR DESCRIPTION
Resolves #18 

The [`format_html`](https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.html.format_html) function has been the suggested way to display potentially unsafe HTML since at least Django 1.8. This change brings the webmention admin display up to speed by replacing the now-deprecated `allow_tags` implementation with `format_html`.