### PR TITLE
Django 4.0 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2023-01-03
+### Added
+- Support for Django 4.0+
+
+### Removed
+- Support for Django versions less than 2.2
+- Support for Python versions less than 3.7
+
+## [2.0.2] - 2021-02-14
+### Fixed
+- Store source content as a string rather than a bytes object
+
+## [2.0.1] - 2020-08-25
+### Fixed
+- Render HTML links in the Django admin by using `format_html` instead of the now-deprecated `allow_tags` attribute
+
+## [2.0.0] - 2020-08-20
+### Removed
+- Support for Python 3.5
+
+### Added
+- Compatibility in the `include_webmention_information` decorator for versions of Django with new-style middleware
+
+## [1.1.0] - 2019-07-22
+### Changed
+- Use static `setup.cfg` for package metadata and tooling configuration
+- Use black code style
+- Lint with pyflakes
+
+## [1.0.1] - 2018-04-12
+### Fixed
+- Made `setup.py` aware that the README content type is, in fact, markdown
+
+## [1.0.0] - 2018-04-12
+### Added
+- Better documentation about testing
+- Coverage configuration
+
+### Changed
+- Use markdown for PyPI README
+
+## [0.1.0] - 2018-01-02
+### Added
+- Mention use of `path()` over `url()` in README
+- Mention use of new-style `MIDDLEWARE` over old-style `MIDDLEWARE_CLASSES` in README
+- Add system check to detect presence of incorrect middleware configuration
+- Update imports and other syntax for forward compatibility with Django 1.10+ and Django 2.0+
+
+## [0.0.4] - 2016-07-15
+### Changed
+- Reworked the unit tests to be runnable under Travis CI to support continuous integration
+
+## [0.0.3] - 2016-01-22
+### Changed
+- Successful POST requests will now receive a 202 Accepted response rather than a 200 OK response
+
+### Added
+- Django 1.9 in frameworks listed in setup.py
+
+### Fixed
+- Errors in documentation
+
+## [0.0.2] - 2015-07-11
+### Added
+- Webmentions are now available for review in the admin console
+- Webmentions are now updated or invalidated when a new webmention notification request is sent
+- Thorough unit testing
+
+## [0.0.1] - 2015-07-10
+### Added
+- Pre-alpha initial release

--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ This package does not currently provide functionality for [sending webmentions](
 * Add `'webmention'` to `INSTALLED_APPS`
 * Run `python manage.py migrate webmention`
 * Add the URL patterns to your top-level `urls.py`
-    * `path('webmention/', include('webmention.urls'))` for Django >= 2.0
-    * `url(r'^webmention', include('webmention.urls', namespace='webmention'))` for Django < 2.0
+    * `path('webmention/', include('webmention.urls'))` for Django >= 3.2
 
 ## Usage
 
 * Include webmention information by either:
     * Installing the middleware in `settings.py` (affects all views)
-        * Use `webmention.middleware.webmention_middleware` in `MIDDLEWARE` for Django >= 1.10
-        * Use `webmention.middleware.WebMentionMiddleware` in `MIDDLEWARE_CLASSES` for older projects
+        * Append `webmention.middleware.webmention_middleware` to your `MIDDLEWARE` settings
     * Decorating a specific view with `webmention.middleware.include_webmention_information`
 * View webmention responses in the Django admin interface and mark them as reviewed as needed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
@@ -75,16 +72,16 @@ python_files =
 addopts = -ra -q --cov=webmention
 
 [tox:tox]
-envlist = {py36,py37,py38,py39,py310,py311}-django{2.2,3.0,3.1,3.2,4.0,4.1}
+envlist = {py37,py38,py39,py310,py311}-django{3.2,4.0,4.1}
 
 [testenv]
 extras = test
 commands =
     pytest {posargs}
 deps =
-    django2.2: Django>=2.2,<2.3
-    django3.0: Django>=3.0,<3.1
-    django3.1: Django>=3.1,<3.2
+    django3.1: Django>=3.2,<3.3
+    django4.0: Django>=4.0,<4.1
+    django4.1: Django>=4.1,<4.2
 
 [testenv:lint]
 extras = lint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-webmention
-version = 2.0.2
+version = 3.0.0
 description = A pluggable implementation of webmention for Django projects
 author = Dane Hillard
 author_email = github@danehillard.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ classifiers =
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Topic :: Internet :: WWW/HTTP :: Indexing/Search
     License :: OSI Approved :: MIT License
     Programming Language :: Python
@@ -24,6 +27,9 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 package_dir = =src
@@ -69,7 +75,7 @@ python_files =
 addopts = -ra -q --cov=webmention
 
 [tox:tox]
-envlist = {py36,py37,py38}-django{2.2,3.0,3.1}
+envlist = {py36,py37,py38,py39,py310,py311}-django{2.2,3.0,3.1,3.2,4.0,4.1}
 
 [testenv]
 extras = test

--- a/src/webmention/urls.py
+++ b/src/webmention/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
@@ -6,4 +6,4 @@ from . import views
 app_name = "webmention"
 
 
-urlpatterns = [url(r"^receive$", views.receive, name="receive")]
+urlpatterns = [re_path(r"^receive$", views.receive, name="receive")]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,11 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
-
+from django.urls import reverse
 from django.http import HttpResponse
 
 from webmention.middleware import WebMentionMiddleware

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,7 +14,7 @@ from webmention.middleware import WebMentionMiddleware
 
 @pytest.fixture
 def middleware():
-    return WebMentionMiddleware()
+    return WebMentionMiddleware(get_response=Mock())
 
 
 def test_process_request_creates_link_header(middleware):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,3 +1,3 @@
-from django.conf.urls import url, include
+from django.urls import re_path, include
 
-urlpatterns = [url(r"^webmention", include("webmention.urls", namespace="webmention"))]
+urlpatterns = [re_path(r"^webmention", include("webmention.urls", namespace="webmention"))]


### PR DESCRIPTION
This PR updates django-webmention to work with Django 4.0 or higher. It does this by:

* Upgrading the urls configuration to use `re_path` instead of the [removed](https://docs.djangoproject.com/en/4.1/releases/4.0/#features-removed-in-4-0) `django.conf.urls.url`.
* Passing in a `get_response` value to the  the middleware test fixture.

In addition, I've also updated the setup.cfg to test/notate compatibility with Python 3.9 - 3.11 and Django 3.2 - 4.1. 